### PR TITLE
Potential fix for code scanning alert no. 355: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,4 +1,6 @@
 name: Vitest
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gnattily/battleship-solitaire/security/code-scanning/355](https://github.com/gnattily/battleship-solitaire/security/code-scanning/355)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only checks out the repository, sets up Node.js, installs dependencies, and runs tests, it only needs `contents: read` permission. This ensures that the workflow has no unnecessary write access.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
