### PR TITLE
64 optimize solve function

### DIFF
--- a/src/app/_board/Board.jsx
+++ b/src/app/_board/Board.jsx
@@ -44,7 +44,7 @@ export default class Board extends React.Component {
 
         // this makes it +1 for left click and +2 for right click (which basically works as -1, but without making it negative)
         const newType = (ship.playType + 1 + event.button / 2) % 3;
-        const board = this.state.board.setShip(index, newType).computeGraphicalTypes();
+        const board = this.state.board.setShip(index, newType).compTypes();
 
         this.setState({ board: board, solved: board.isSolved(), draggedType: newType });
     }
@@ -52,7 +52,7 @@ export default class Board extends React.Component {
     onMouseEnter (index) {
         if (this.state.board.getShip(index).pinned || !this.state.draggedType) return;
 
-        const board = this.state.board.setShip(index, this.state.draggedType).computeGraphicalTypes();
+        const board = this.state.board.setShip(index, this.state.draggedType).compTypes();
         this.setState({ board: board, solved: board.isSolved() });
     }
 

--- a/src/app/_board/BoardBuilder.js
+++ b/src/app/_board/BoardBuilder.js
@@ -263,7 +263,7 @@ export default class BoardBuilder {
         board.compTypes();
 
         for (let i = 0; i < ITERATION_LIMIT; i++) {
-            // check for full or would-be-full rows/columns
+            const old = board.copy();
 
             for (let y = 0; y < board.height; y++) {
                 const counts = board.countRow(y);
@@ -297,7 +297,7 @@ export default class BoardBuilder {
             // -TODO -URGENT
             // make this only place one ship, rerun the whole thing, then do another ship, etc.
             // when you do that, set the for loop condition back to i > 1
-            if (cache?.sameBoardState(board)) {
+            if (old?.sameBoardState(board)) {
                 const shipsLeft = board.countRunsLeft(true);
                 const horizontalRuns = board.getHorizontalRuns();
                 const verticalRuns = board.getVerticalRuns();
@@ -392,7 +392,7 @@ export default class BoardBuilder {
 
             board.compTypes();
 
-            if (board?.sameBoardState(cache)) return board;
+            if (board?.sameBoardState(old)) return board;
             if (board?.isSolved()) return board;
         }
 

--- a/src/app/_board/BoardBuilder.test.js
+++ b/src/app/_board/BoardBuilder.test.js
@@ -1,8 +1,7 @@
 import { expect, test } from 'vitest';
 
-import BoardBuilder, { RELATIVE_POSITIONS } from './BoardBuilder';
+import BoardBuilder, { REL_POS } from './BoardBuilder';
 import Ship, { GRAPHICAL_TYPES, PLAY_TYPES } from './Ship';
-import { displayBoard, GRID_TYPES } from './BoardUtils';
 
 test('constructor', () => {
     const badPreset = new BoardBuilder(4, 5);
@@ -383,7 +382,7 @@ test('computeGraphicalTypes', () => {
         .softFloodRow(4)
         .setShip([1, 2], GRAPHICAL_TYPES.RIGHT);
 
-    expect(board.computeGraphicalTypes() instanceof BoardBuilder).toBeTruthy();
+    expect(board.compTypes() instanceof BoardBuilder).toBeTruthy();
 
     expect(board.getShip(0).graphicalType).toBe(GRAPHICAL_TYPES.RIGHT);
     expect(board.getShip(1).graphicalType).toBe(GRAPHICAL_TYPES.HORIZONTAL);
@@ -461,9 +460,9 @@ test('softSetShip', () => {
 test('relativePositionToIndex', () => {
     const board = new BoardBuilder(4, 4);
 
-    expect(board.relativePositionToIndex(0, RELATIVE_POSITIONS.RIGHT)).toBe(1);
-    expect(board.relativePositionToIndex(0, RELATIVE_POSITIONS.LEFT)).toBeNull();
-    expect(board.relativePositionToIndex(3, RELATIVE_POSITIONS.RIGHT)).toBeNull();
+    expect(board.relativePositionToIndex(0, REL_POS.RIGHT)).toBe(1);
+    expect(board.relativePositionToIndex(0, REL_POS.LEFT)).toBeNull();
+    expect(board.relativePositionToIndex(3, REL_POS.RIGHT)).toBeNull();
 });
 
 test('getRelativeShip', () => {
@@ -472,22 +471,22 @@ test('getRelativeShip', () => {
     board.setShip(1, PLAY_TYPES.WATER);
     board.setShip(4, GRAPHICAL_TYPES.VERTICAL);
 
-    expect(board.getRelativeShip(0, RELATIVE_POSITIONS.BOTTOM).graphicalType).toBe(GRAPHICAL_TYPES.VERTICAL);
-    expect(board.getRelativeShip(0, RELATIVE_POSITIONS.LEFT)).toBeNull();
-    expect(board.getRelativeShip(0, RELATIVE_POSITIONS.RIGHT).playType).toBe(PLAY_TYPES.WATER);
+    expect(board.getRelativeShip(0, REL_POS.BOTTOM).graphicalType).toBe(GRAPHICAL_TYPES.VERTICAL);
+    expect(board.getRelativeShip(0, REL_POS.LEFT)).toBeNull();
+    expect(board.getRelativeShip(0, REL_POS.RIGHT).playType).toBe(PLAY_TYPES.WATER);
 });
 
 test('setRelativeShip', () => {
     const board = new BoardBuilder(4, 4);
 
-    expect(board.setRelativeShip(0, RELATIVE_POSITIONS.RIGHT, PLAY_TYPES.SHIP) instanceof BoardBuilder).toBeTruthy();
-    expect(board.setRelativeShip(0, RELATIVE_POSITIONS.LEFT, PLAY_TYPES.SHIP)).toBeNull();
+    expect(board.setRelativeShip(0, REL_POS.RIGHT, PLAY_TYPES.SHIP)).toBeTruthy();
+    expect(board.setRelativeShip(0, REL_POS.LEFT, PLAY_TYPES.SHIP)).toBeNull();
     expect(board.boardState[1].playType).toBe(PLAY_TYPES.SHIP);
 });
 
 test('setCardinalShips', () => {
     const board = new BoardBuilder(4, 4);
-    expect(board.setCardinalShips([1, 1], RELATIVE_POSITIONS.TOP) instanceof BoardBuilder).toBeTruthy();
+    expect(board.setCardinalShips([1, 1], REL_POS.TOP) instanceof BoardBuilder).toBeTruthy();
 
     expect(board.boardState[0].playType).toBe(PLAY_TYPES.WATER);
     expect(board.boardState[1].playType).toBe(PLAY_TYPES.SHIP);

--- a/src/app/_board/BoardBuilder.test.js
+++ b/src/app/_board/BoardBuilder.test.js
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 
 import BoardBuilder, { RELATIVE_POSITIONS } from './BoardBuilder';
 import Ship, { GRAPHICAL_TYPES, PLAY_TYPES } from './Ship';
+import { displayBoard, GRID_TYPES } from './BoardUtils';
 
 test('constructor', () => {
     const badPreset = new BoardBuilder(4, 5);

--- a/src/app/_board/BoardUtils.js
+++ b/src/app/_board/BoardUtils.js
@@ -8,24 +8,35 @@
 
 */
 
+const RESET = '\x1b[0m';
+const CYAN = '\x1b[36m';
+const WHITE = '\x1b[37m';
+const GRAY = '\x1b[90m';
+
+const BRIGHT = '\x1b[1m';
+const DIM = '\x1b[2m';
+
 import BoardBuilder from './BoardBuilder';
+import { PLAY_TYPES } from './Ship';
 
 /**
  * Prints out a representation of the board to the console
  * @param {BoardBuilder} board - The board to display
- * @param {number} [gridType=0] - 0 for no grid, 1 for minimal, 2 for square
+ * @param {number} [gridType=2] - 0 for no grid, 1 for minimal, 2 for full
  */
-export function displayBoard (board, gridType = 0) {
+export function displayBoard (board, gridType = GRID_TYPES.FULL) {
     switch (gridType) {
         case (GRID_TYPES.NONE):
             for (let y = 0; y < board.height; y++) {
-                let line = '';
+                let out = '';
 
                 for (let x = 0; x < board.width; x++) {
-                    line += board.getShip([x, y]);
+                    const ship = board.getShip([x, y]);
+                    if (ship.playType === PLAY_TYPES.WATER) out += DIM + CYAN;
+                    out += ship + RESET;
                 }
 
-                console.log(line);
+                console.log(out);
             }
 
             break;
@@ -34,11 +45,12 @@ export function displayBoard (board, gridType = 0) {
             printEnd(board.width, gridType, true);
 
             for (let y = 0; y < board.height; y++) {
-                let out = '│';
+                let out = GRAY + '│' + RESET;
 
                 for (let x = 0; x < board.width; x++) {
                     const ship = board.getShip([x, y]);
-                    out += gridType === GRID_TYPES.MINIMAL ? `${ship}│` : ` ${ship} |`;
+                    if (ship.playType === PLAY_TYPES.WATER) out += DIM + CYAN;
+                    out += BRIGHT + WHITE + (gridType === GRID_TYPES.MINIMAL ? `${ship}` : ` ${ship} `) + `${GRAY}│${RESET}`;
                 }
 
                 console.log(out);
@@ -54,24 +66,24 @@ export function displayBoard (board, gridType = 0) {
 }
 
 function printEnd (width, gridType, top) {
-    let out = top ? '┌' : '└';
+    let out = GRAY + (top ? '┌' : '└');
 
     for (let i = 0; i < width; i++) {
         out += gridType === GRID_TYPES.MINIMAL ? '─' : '───';
         out += top ? '┬' : '┴';
     }
 
-    console.log(out.slice(0, -1) + (top ? '┐' : '┘'));
+    console.log(out.slice(0, -1) + (top ? '┐' : '┘') + RESET);
 }
 
 function printBar (width, gridType) {
-    let out = '├';
+    let out = GRAY + '├';
 
     for (let i = 0; i < width; i++) {
         out += gridType === GRID_TYPES.MINIMAL ? '─┼' : '───┼';
     }
 
-    console.log(out.slice(0, -1) + '┤');
+    console.log(out.slice(0, -1) + '┤' + RESET);
 }
 
 /**

--- a/src/app/_board/BoardUtils.js
+++ b/src/app/_board/BoardUtils.js
@@ -1,0 +1,84 @@
+/*
+
+┌───┬───┐
+│   │   │
+├───┼───┤
+│   │   │
+└───┴───┘
+
+*/
+
+import BoardBuilder from './BoardBuilder';
+
+/**
+ * Prints out a representation of the board to the console
+ * @param {BoardBuilder} board - The board to display
+ * @param {number} [gridType=0] - 0 for no grid, 1 for minimal, 2 for square
+ */
+export function displayBoard (board, gridType = 0) {
+    switch (gridType) {
+        case (GRID_TYPES.NONE):
+            for (let y = 0; y < board.height; y++) {
+                let line = '';
+
+                for (let x = 0; x < board.width; x++) {
+                    line += board.getShip([x, y]);
+                }
+
+                console.log(line);
+            }
+
+            break;
+        case (GRID_TYPES.MINIMAL):
+        case (GRID_TYPES.FULL):
+            printEnd(board.width, gridType, true);
+
+            for (let y = 0; y < board.height; y++) {
+                let out = '│';
+
+                for (let x = 0; x < board.width; x++) {
+                    const ship = board.getShip([x, y]);
+                    out += gridType === GRID_TYPES.MINIMAL ? `${ship}│` : ` ${ship} |`;
+                }
+
+                console.log(out);
+
+                if (y < board.height - 1) printBar(board.width, gridType);
+            }
+
+            printEnd(board.width, gridType, false);
+            break;
+        default:
+            throw new RangeError('gridType should be an integer 0-2, received: ' + gridType);
+    }
+}
+
+function printEnd (width, gridType, top) {
+    let out = top ? '┌' : '└';
+
+    for (let i = 0; i < width; i++) {
+        out += gridType === GRID_TYPES.MINIMAL ? '─' : '───';
+        out += top ? '┬' : '┴';
+    }
+
+    console.log(out.slice(0, -1) + (top ? '┐' : '┘'));
+}
+
+function printBar (width, gridType) {
+    let out = '├';
+
+    for (let i = 0; i < width; i++) {
+        out += gridType === GRID_TYPES.MINIMAL ? '─┼' : '───┼';
+    }
+
+    console.log(out.slice(0, -1) + '┤');
+}
+
+/**
+ * @constant
+ */
+export const GRID_TYPES = {
+    NONE: 0,
+    MINIMAL: 1,
+    FULL: 2,
+};

--- a/src/app/_board/Ship.js
+++ b/src/app/_board/Ship.js
@@ -20,25 +20,25 @@ export default class Ship {
     toString () {
         switch (this.graphicalType) {
             case GRAPHICAL_TYPES.UNKNOWN:
-                return 'Unknown';
+                return ' ';
             case GRAPHICAL_TYPES.WATER:
-                return 'Water';
+                return '☵';
             case GRAPHICAL_TYPES.SHIP:
-                return 'Ship';
+                return '◯';
             case GRAPHICAL_TYPES.DOWN:
-                return 'Down';
+                return '⯅';
             case GRAPHICAL_TYPES.HORIZONTAL:
-                return 'Horizontal';
+                return '■';
             case GRAPHICAL_TYPES.LEFT:
-                return 'Left';
+                return '⯈';
             case GRAPHICAL_TYPES.RIGHT:
-                return 'Right';
+                return '⯇';
             case GRAPHICAL_TYPES.SINGLE:
-                return 'Single';
+                return '●';
             case GRAPHICAL_TYPES.UP:
-                return 'Up';
+                return '⯆';
             case GRAPHICAL_TYPES.VERTICAL:
-                return 'Vertical';
+                return '■';
             default:
                 throw new Error('graphicalType is not a valid graphical type');
         }
@@ -82,9 +82,7 @@ export default class Ship {
      * @returns {boolean} true if equal, false if not
      */
     equals (comparate) {
-        return (
-            this.graphicalType === comparate.graphicalType
-        );
+        return this.graphicalType === comparate.graphicalType;
     }
 
     /**

--- a/src/app/_board/Ship.js
+++ b/src/app/_board/Ship.js
@@ -1,4 +1,4 @@
-import { RELATIVE_POSITIONS } from './BoardBuilder';
+import { REL_POS } from './BoardBuilder';
 
 /**
  * The ship class for the board
@@ -151,13 +151,13 @@ export default class Ship {
     static graphicalTypeToRelativePosition (graphicalType) {
         switch (graphicalType) {
             case GRAPHICAL_TYPES.LEFT:
-                return RELATIVE_POSITIONS.LEFT;
+                return REL_POS.LEFT;
             case GRAPHICAL_TYPES.RIGHT:
-                return RELATIVE_POSITIONS.RIGHT;
+                return REL_POS.RIGHT;
             case GRAPHICAL_TYPES.UP:
-                return RELATIVE_POSITIONS.TOP;
+                return REL_POS.TOP;
             case GRAPHICAL_TYPES.DOWN:
-                return RELATIVE_POSITIONS.BOTTOM;
+                return REL_POS.BOTTOM;
             default:
                 throw new Error(`${graphicalType} has no single corresponding relative position`);
         }

--- a/src/app/_board/Ship.test.js
+++ b/src/app/_board/Ship.test.js
@@ -1,14 +1,9 @@
 import { expect, test } from 'vitest';
 
-import { RELATIVE_POSITIONS } from './BoardBuilder';
+import { REL_POS } from './BoardBuilder';
 import Ship, { GRAPHICAL_TYPES, PLAY_TYPES } from './Ship';
 
 test('toString', () => {
-    for (const type in GRAPHICAL_TYPES) {
-        const ship = new Ship(GRAPHICAL_TYPES[type]);
-        expect(ship.toString().toUpperCase()).toBe(type);
-    }
-
     const ship = new Ship(GRAPHICAL_TYPES.UNKNOWN);
     ship.graphicalType = 10;
 
@@ -164,10 +159,10 @@ test('graphicalTypeToRelativePosition', () => {
     const ship5 = GRAPHICAL_TYPES.HORIZONTAL;
     const ship6 = PLAY_TYPES.SHIP;
 
-    expect(Ship.graphicalTypeToRelativePosition(ship1)).toBe(RELATIVE_POSITIONS.LEFT);
-    expect(Ship.graphicalTypeToRelativePosition(ship2)).toBe(RELATIVE_POSITIONS.RIGHT);
-    expect(Ship.graphicalTypeToRelativePosition(ship3)).toBe(RELATIVE_POSITIONS.TOP);
-    expect(Ship.graphicalTypeToRelativePosition(ship4)).toBe(RELATIVE_POSITIONS.BOTTOM);
+    expect(Ship.graphicalTypeToRelativePosition(ship1)).toBe(REL_POS.LEFT);
+    expect(Ship.graphicalTypeToRelativePosition(ship2)).toBe(REL_POS.RIGHT);
+    expect(Ship.graphicalTypeToRelativePosition(ship3)).toBe(REL_POS.TOP);
+    expect(Ship.graphicalTypeToRelativePosition(ship4)).toBe(REL_POS.BOTTOM);
 
     expect(() => { Ship.graphicalTypeToRelativePosition(ship5); }).toThrow('has no single corresponding relative position');
     expect(() => { Ship.graphicalTypeToRelativePosition(ship6); }).toThrow('has no single corresponding relative position');

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -48,7 +48,7 @@ const preset = new BoardBuilder(15, 15, undefined,
     .setShip([6, 13], GRAPHICAL_TYPES.WATER, true)
     .setShip([3, 14], GRAPHICAL_TYPES.WATER, true)
     .setShip([14, 14], GRAPHICAL_TYPES.SINGLE, true)
-    .computeGraphicalTypes()
+    .compTypes()
     .export();
 
 export default function Page () {


### PR DESCRIPTION
Reduced the average time of the `solve()` test from ~140ms to ~43ms, dipping as low as 21ms on repeated runs. This was accomplished simply by fixing the function to work as intended and by using a for loop in place of a recursive function.

Added a terminal based board viewer in `./src/app/_board/BoardUtils.js.` Since it is solely for development, it will not be included in testing.