### PR TITLE
Potential fix for code scanning alert no. 356: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,5 +1,8 @@
 name: Vitest
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/gnattily/battleship-solitaire/security/code-scanning/356](https://github.com/gnattily/battleship-solitaire/security/code-scanning/356)

To address the issue, we will add a `permissions` block to the workflow file. The permissions will be set at the root level of the workflow to apply to all jobs unless overridden explicitly. Based on the tasks performed by the workflow, the `contents: read` permission suffices, as the workflow only requires read access to the repository content (e.g., for checkout purposes). No write permissions are necessary. This ensures the principle of least privilege is adhered to.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
